### PR TITLE
Add Swagger setup to the project

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'knox',
+    'drf_yasg',
     'users.apps.UsersConfig',
     'video',
     'transcript',

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -14,12 +14,36 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import include, path
-from rest_framework import routers
+from django.urls import include, path, re_path
+from rest_framework import routers, permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+from drf_yasg.generators import OpenAPISchemaGenerator
+
+## Utility Classes 
+class BothHttpAndHttpsSchemaGenerator(OpenAPISchemaGenerator):
+    def get_schema(self, request=None, public=False):
+        schema = super().get_schema(request, public)
+        schema.schemes = ["http", "https"]
+        return schema
 
 router = routers.DefaultRouter()
 # Register the viewsets
 
+# Add the swagger view 
+schema_view = get_schema_view(
+   openapi.Info(
+      title="Chitralekha API Docs",
+      default_version='v1',
+      description="API documentation for Chitralekha Platform.",
+      terms_of_service="https://www.google.com/policies/terms/",
+      contact=openapi.Contact(email="contact@snippets.local"),
+      license=openapi.License(name="BSD License"),
+   ),
+   generator_class=BothHttpAndHttpsSchemaGenerator,
+   public=True,
+   permission_classes=[permissions.AllowAny],
+)
 
 urlpatterns = [
     path('', include(router.urls)),
@@ -28,4 +52,7 @@ urlpatterns = [
     path('video/', include('video.urls')),
     path('translation/', include('translation.urls')),
     path('transcript/', include('transcript.urls')),
+    re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]


### PR DESCRIPTION
Swagger has been set up in the project using `drf-yasg`. This allows us to test the APIs through Swagger as well. 

This pull request adds the initial setup config to the `backend\urls.py` and `backend\settings.py`. 