### PR TITLE
fixed the issue of not able to delete trancript edit task if status is failed

### DIFF
--- a/backend/task/views.py
+++ b/backend/task/views.py
@@ -1879,8 +1879,18 @@ class TaskViewSet(ModelViewSet):
                 ]
             else:
                 tasks_to_delete = [transcript.task for transcript in transcripts]
-
-            for transcript in transcripts.all():
+                if len(transcripts)==0:
+                    if task.status=="FAILED":
+                        tasks_to_delete.append(task)
+                    if task.status=="SELECTED_SOURCE":
+                        return Response(
+                        {
+                            "message": "The Transcript Generation still under progress, please try again after sometime.",
+                        },
+                        status=status.HTTP_409_CONFLICT,
+                    )
+                    
+            if len(tasks_to_delete):
                 for translation in Translation.objects.filter(video=task.video).all():
                     translation_tasks.add(translation.task)
                     for voiceover in (


### PR DESCRIPTION
- Added condition to handle failed transcription task delete
- Replaced redundant outer for loop statement(which is executing same code block in each loop), with if condition.
